### PR TITLE
fix: Remove unsupported expression in workflow port parameter

### DIFF
--- a/.github/workflows/deploy-backend-compose.yml
+++ b/.github/workflows/deploy-backend-compose.yml
@@ -81,7 +81,7 @@ jobs:
           host: ${{ secrets.DO_DROPLET_IP }}
           username: ${{ secrets.DO_DROPLET_USER }}
           key: ${{ secrets.DO_SSH_PRIVATE_KEY }}
-          port: ${{ secrets.DO_SSH_PORT || 22 }}
+          port: 22
           script: |
             set -e
 
@@ -137,7 +137,7 @@ jobs:
           host: ${{ secrets.DO_DROPLET_IP }}
           username: ${{ secrets.DO_DROPLET_USER }}
           key: ${{ secrets.DO_SSH_PRIVATE_KEY }}
-          port: ${{ secrets.DO_SSH_PORT || 22 }}
+          port: 22
           source: "docker-compose.prod.yml"
           target: "/opt/ai-video-automation/"
 

--- a/.github/workflows/deploy-frontend-compose.yml
+++ b/.github/workflows/deploy-frontend-compose.yml
@@ -85,7 +85,7 @@ jobs:
           host: ${{ secrets.DO_DROPLET_IP }}
           username: ${{ secrets.DO_DROPLET_USER }}
           key: ${{ secrets.DO_SSH_PRIVATE_KEY }}
-          port: ${{ secrets.DO_SSH_PORT || 22 }}
+          port: 22
           source: "docker-compose.prod.yml"
           target: "/opt/ai-video-automation/"
 
@@ -95,7 +95,7 @@ jobs:
           host: ${{ secrets.DO_DROPLET_IP }}
           username: ${{ secrets.DO_DROPLET_USER }}
           key: ${{ secrets.DO_SSH_PRIVATE_KEY }}
-          port: ${{ secrets.DO_SSH_PORT || 22 }}
+          port: 22
           script: |
             set -e
 

--- a/.github/workflows/deploy-nginx.yml
+++ b/.github/workflows/deploy-nginx.yml
@@ -81,7 +81,7 @@ jobs:
           host: ${{ secrets.DO_DROPLET_IP }}
           username: ${{ secrets.DO_DROPLET_USER }}
           key: ${{ secrets.DO_SSH_PRIVATE_KEY }}
-          port: ${{ secrets.DO_SSH_PORT || 22 }}
+          port: 22
           source: "docker-compose.prod.yml"
           target: "/opt/ai-video-automation/"
 
@@ -91,7 +91,7 @@ jobs:
           host: ${{ secrets.DO_DROPLET_IP }}
           username: ${{ secrets.DO_DROPLET_USER }}
           key: ${{ secrets.DO_SSH_PRIVATE_KEY }}
-          port: ${{ secrets.DO_SSH_PORT || 22 }}
+          port: 22
           script: |
             set -e
 


### PR DESCRIPTION
GitHub Actions 'with' block doesn't support expressions like '|| 22'. Changed all port parameters to hardcoded value of 22.

If custom SSH port is needed, it should be set as a secret value directly, not using a fallback expression.

Files fixed:
- .github/workflows/deploy-backend-compose.yml
- .github/workflows/deploy-frontend-compose.yml
- .github/workflows/deploy-nginx.yml