### PR TITLE
feat: Auto-deploy all services on push to main

### DIFF
--- a/.github/workflows/deploy-backend-compose.yml
+++ b/.github/workflows/deploy-backend-compose.yml
@@ -1,12 +1,23 @@
 name: Deploy Backend (Docker Compose)
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'features/**'
+      - 'pyproject.toml'
+      - 'Dockerfile'
+      - 'main.py'
+      - 'main_v2.py'
+      - 'docker-compose.prod.yml'
+      - '.github/workflows/deploy-backend-compose.yml'
   workflow_dispatch:
     inputs:
       branch:
         description: 'Branch to deploy'
         required: true
-        default: 'deployment/github-actions-setup'
+        default: 'main'
         type: choice
         options:
           - main
@@ -30,7 +41,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.branch }}
+          ref: ${{ github.event.inputs.branch || github.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -73,7 +84,7 @@ jobs:
       - name: Checkout code (for docker-compose.prod.yml)
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.branch }}
+          ref: ${{ github.event.inputs.branch || github.ref }}
 
       - name: Deploy to Digital Ocean via Docker Compose
         uses: appleboy/ssh-action@v1.2.0

--- a/.github/workflows/deploy-frontend-compose.yml
+++ b/.github/workflows/deploy-frontend-compose.yml
@@ -1,12 +1,19 @@
 name: Deploy Frontend (Docker Compose)
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'web/**'
+      - 'docker-compose.prod.yml'
+      - '.github/workflows/deploy-frontend-compose.yml'
   workflow_dispatch:
     inputs:
       branch:
         description: 'Branch to deploy'
         required: true
-        default: 'deployment/github-actions-setup'
+        default: 'main'
         type: choice
         options:
           - main
@@ -30,7 +37,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.branch }}
+          ref: ${{ github.event.inputs.branch || github.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -77,7 +84,7 @@ jobs:
       - name: Checkout code (for docker-compose.prod.yml)
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.branch }}
+          ref: ${{ github.event.inputs.branch || github.ref }}
 
       - name: Copy docker-compose.prod.yml to droplet
         uses: appleboy/scp-action@v0.1.7

--- a/.github/workflows/deploy-nginx.yml
+++ b/.github/workflows/deploy-nginx.yml
@@ -1,12 +1,19 @@
 name: Deploy Nginx (Docker Compose)
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'nginx/**'
+      - 'docker-compose.prod.yml'
+      - '.github/workflows/deploy-nginx.yml'
   workflow_dispatch:
     inputs:
       branch:
         description: 'Branch to deploy'
         required: true
-        default: 'deployment/github-actions-setup'
+        default: 'main'
         type: choice
         options:
           - main
@@ -30,7 +37,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.branch }}
+          ref: ${{ github.event.inputs.branch || github.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -73,7 +80,7 @@ jobs:
       - name: Checkout code (for docker-compose.prod.yml)
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.branch }}
+          ref: ${{ github.event.inputs.branch || github.ref }}
 
       - name: Copy docker-compose.prod.yml to droplet
         uses: appleboy/scp-action@v0.1.7


### PR DESCRIPTION
Updated docker-compose deployment workflows to automatically trigger on push to main branch.

Changes:
- Backend deploys on changes to backend code, Dockerfile, or docker-compose.prod.yml
- Frontend deploys on changes to web/, or docker-compose.prod.yml
- Nginx deploys on changes to nginx/, or docker-compose.prod.yml

Workflow triggers:
- On push to main (automatic deployment)
- Manual dispatch (for ad-hoc deployments from any branch)

Branch handling:
- Uses github.event.inputs.branch for manual dispatches
- Uses github.ref for automatic push triggers
- Fallback ensures correct branch is always checked out

Path filters ensure only relevant services are deployed when their code changes, avoiding unnecessary deployments and saving CI/CD time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)