### PR TITLE
fix: Resolve workflow validation and frontend build errors

### DIFF
--- a/.github/workflows/backend-ci-cd.yml
+++ b/.github/workflows/backend-ci-cd.yml
@@ -118,7 +118,7 @@ jobs:
 
     environment:
       name: production-backend
-      url: http://${{ secrets.DO_DROPLET_IP }}:8000
+      url: https://vingine.duckdns.org
 
     steps:
       - name: Checkout code

--- a/.github/workflows/frontend-ci-cd.yml
+++ b/.github/workflows/frontend-ci-cd.yml
@@ -119,7 +119,7 @@ jobs:
 
     environment:
       name: production-frontend
-      url: http://${{ secrets.DO_DROPLET_IP }}:3000
+      url: https://vingine.duckdns.org
 
     steps:
       - name: Checkout code

--- a/web/src/app/auth/callback/route.ts
+++ b/web/src/app/auth/callback/route.ts
@@ -18,9 +18,13 @@ export async function GET(request: NextRequest) {
             return cookieStore.getAll()
           },
           setAll(cookiesToSet) {
-            cookiesToSet.forEach(({ name, value, options }) =>
-              cookieStore.set(name, value, options)
-            )
+            try {
+              cookiesToSet.forEach(({ name, value, options }) =>
+                cookieStore.set(name, value, options)
+              )
+            } catch {
+              // Ignore errors during build time
+            }
           },
         },
       }


### PR DESCRIPTION
Fixed multiple issues preventing successful builds and deployments:

1. GitHub Actions workflow validation errors:
   - Changed environment.url from dynamic secret to static domain
   - GitHub Actions doesn't support secrets in environment.url field
   - backend-ci-cd.yml: url now points to https://vingine.duckdns.org
   - frontend-ci-cd.yml: url now points to https://vingine.duckdns.org

2. Frontend build error in auth callback:
   - Added try-catch around cookieStore.set() calls
   - Prevents build-time errors when cookie operations fail
   - File: web/src/app/auth/callback/route.ts

Error resolved:
"Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.DO_DROPLET_IP"

This was occurring in the environment.url field, not the port field as initially thought.

🤖 Generated with [Claude Code](https://claude.com/claude-code)