### PR TITLE
feat: Make builds run in parallel for faster CI

### DIFF
--- a/.github/workflows/deploy-all-services.yml
+++ b/.github/workflows/deploy-all-services.yml
@@ -26,7 +26,7 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  # Build jobs run sequentially
+  # Build jobs run in parallel
   build-backend:
     name: Build Backend Image
     runs-on: ubuntu-latest
@@ -75,8 +75,7 @@ jobs:
   build-frontend:
     name: Build Frontend Image
     runs-on: ubuntu-latest
-    needs: build-backend
-    if: always() && (github.event_name == 'push' || github.event.inputs.deploy_frontend == 'true')
+    if: github.event_name == 'push' || github.event.inputs.deploy_frontend == 'true'
 
     permissions:
       contents: read
@@ -125,8 +124,7 @@ jobs:
   build-nginx:
     name: Build Nginx Image
     runs-on: ubuntu-latest
-    needs: build-frontend
-    if: always() && (github.event_name == 'push' || github.event.inputs.deploy_nginx == 'true')
+    if: github.event_name == 'push' || github.event.inputs.deploy_nginx == 'true'
 
     permissions:
       contents: read


### PR DESCRIPTION
Changed build jobs to run in parallel instead of sequentially:
- build-backend ⚡
- build-frontend ⚡
- build-nginx ⚡

All three builds start simultaneously, then deployments run in parallel after all builds complete.

Removed 'needs' dependencies between build jobs for maximum parallelization.

Total workflow:
1. Builds (parallel) → 2. Deploys (parallel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)