### PR TITLE
fix: Add TypeScript declaration for swagger-ui-react module

### DIFF
--- a/web/src/types/swagger-ui-react.d.ts
+++ b/web/src/types/swagger-ui-react.d.ts
@@ -1,0 +1,16 @@
+declare module 'swagger-ui-react' {
+  import { Component } from 'react';
+
+  interface SwaggerUIProps {
+    spec?: any;
+    url?: string;
+    onComplete?: (system: any) => void;
+    requestInterceptor?: (req: any) => any;
+    responseInterceptor?: (res: any) => any;
+    docExpansion?: 'list' | 'full' | 'none';
+    defaultModelsExpandDepth?: number;
+    [key: string]: any;
+  }
+
+  export default class SwaggerUI extends Component<SwaggerUIProps> {}
+}


### PR DESCRIPTION
Added type declaration file to resolve build error: 'Could not find a declaration file for module swagger-ui-react'

Created web/src/types/swagger-ui-react.d.ts with proper interface definitions for SwaggerUI component props.

This allows the frontend build to succeed without requiring @types/swagger-ui-react package which doesn't exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)