### PR TITLE
fix: Use type assertion for AgentNode data prop

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -37,7 +37,12 @@
       "Bash(DOCKER_HOST=unix:///Users/parabolabam/.colima/default/docker.sock docker-compose restart:*)",
       "Bash(DOCKER_HOST=unix:///Users/parabolabam/.colima/default/docker.sock docker-compose exec:*)",
       "Bash(npx tsc --noEmit)",
-      "Bash(npm run lint)"
+      "Bash(npm run lint)",
+      "Bash(export NVM_DIR=\"$HOME/.nvm\")",
+      "Bash([ -s \"$NVM_DIR/nvm.sh\" ])",
+      "Bash(. \"$NVM_DIR/nvm.sh\")",
+      "Bash(nvm use default)",
+      "Bash(npm run build:*)"
     ]
   }
 }

--- a/web/src/components/agent-node.tsx
+++ b/web/src/components/agent-node.tsx
@@ -12,7 +12,8 @@ interface AgentNodeData {
   systemInstructions?: string;
 }
 
-export const AgentNode = memo(({ data }: NodeProps<AgentNodeData>) => {
+export const AgentNode = memo(({ data }: NodeProps) => {
+  const nodeData = data as AgentNodeData;
   return (
     <Card className="min-w-[250px] shadow-lg">
       <Handle type="target" position={Position.Top} className="w-3 h-3" />
@@ -20,26 +21,26 @@ export const AgentNode = memo(({ data }: NodeProps<AgentNodeData>) => {
       <CardHeader className="pb-2">
         <CardTitle className="text-sm flex items-center gap-2">
           <Bot className="h-4 w-4" />
-          {data.label}
+          {nodeData.label}
         </CardTitle>
       </CardHeader>
 
       <CardContent className="space-y-2">
         <div className="flex items-center justify-between">
           <span className="text-xs text-muted-foreground">Role:</span>
-          <Badge variant="outline" className="text-xs">{data.role}</Badge>
+          <Badge variant="outline" className="text-xs">{nodeData.role}</Badge>
         </div>
 
         <div className="flex items-center justify-between">
           <span className="text-xs text-muted-foreground">Model:</span>
-          <span className="text-xs font-mono">{data.model}</span>
+          <span className="text-xs font-mono">{nodeData.model}</span>
         </div>
 
-        {data.tools && data.tools.length > 0 && (
+        {nodeData.tools && nodeData.tools.length > 0 && (
           <div>
             <span className="text-xs text-muted-foreground">Tools:</span>
             <div className="flex flex-wrap gap-1 mt-1">
-              {data.tools.map((tool: string, i: number) => (
+              {nodeData.tools.map((tool: string, i: number) => (
                 <Badge key={i} variant="secondary" className="text-xs">
                   {tool}
                 </Badge>
@@ -48,9 +49,9 @@ export const AgentNode = memo(({ data }: NodeProps<AgentNodeData>) => {
           </div>
         )}
 
-        {data.systemInstructions && (
+        {nodeData.systemInstructions && (
           <div className="text-xs text-muted-foreground mt-2 line-clamp-2">
-            {data.systemInstructions}
+            {nodeData.systemInstructions}
           </div>
         )}
       </CardContent>


### PR DESCRIPTION
Fixed TypeScript error by using type assertion instead of generic constraint. NodeProps expects a full Node type, not just the data interface.

Changed from:
  NodeProps<AgentNodeData>

To:
  NodeProps with data type assertion
  const nodeData = data as AgentNodeData

This resolves the build error:
'Type AgentNodeData does not satisfy the constraint Node'

🤖 Generated with [Claude Code](https://claude.com/claude-code)