### PR TITLE
fix: Use double type assertion for AgentNode data

### DIFF
--- a/web/src/components/agent-node.tsx
+++ b/web/src/components/agent-node.tsx
@@ -13,7 +13,7 @@ interface AgentNodeData {
 }
 
 export const AgentNode = memo(({ data }: NodeProps) => {
-  const nodeData = data as AgentNodeData;
+  const nodeData = data as unknown as AgentNodeData;
   return (
     <Card className="min-w-[250px] shadow-lg">
       <Handle type="target" position={Position.Top} className="w-3 h-3" />


### PR DESCRIPTION
Fixed TypeScript error by using double type assertion (as unknown as). This is required when TypeScript cannot verify the type conversion directly.

Changed from:
  data as AgentNodeData

To:
  data as unknown as AgentNodeData

🤖 Generated with [Claude Code](https://claude.com/claude-code)