### PR TITLE
fix: Route /api/trpc/ to frontend in SSL nginx config

### DIFF
--- a/nginx/vingine.conf.template
+++ b/nginx/vingine.conf.template
@@ -37,6 +37,19 @@ server {
     # Allow large file uploads (for video processing)
     client_max_body_size 500M;
 
+    # Frontend tRPC API (must come before /api/ to match first)
+    location /api/trpc/ {
+        proxy_pass http://${FRONTEND_HOST}:${FRONTEND_PORT}/api/trpc/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Backend API routes
     location /api/ {
         proxy_pass http://${BACKEND_HOST}:${BACKEND_PORT}/api/;


### PR DESCRIPTION
Add specific location block for /api/trpc/ that routes to the frontend Next.js server instead of the backend FastAPI server. This must come before the general /api/ block to match first.

The tRPC server runs in the Next.js frontend at /api/trpc/[trpc]/route.ts and acts as a proxy to the backend REST API. Previously, nginx was routing /api/trpc/ requests to the backend which doesn't have a tRPC server, causing 404 errors.

This mirrors the fix already applied to vingine-http-only.conf.template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)